### PR TITLE
Update Docker phantomJS version, fix database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /jail_dashboard
 WORKDIR /jail_dashboard
 
 # Install PhantomJS
-ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+ENV PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
 
 RUN apt-get install -y \
   build-essential \

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,10 +7,6 @@ development: &default
   password: postgres
   host: <%= ENV.fetch("DATABASE_HOST", "localhost") %>
 
-# test:
-#   <<: *default
-#   database: jail_dashboard_test
-
 test:
-  adapter: postgresql
-  database: travis_ci_test
+  <<: *default
+  database: jail_dashboard_test

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,4 +9,4 @@ development: &default
 
 test:
   <<: *default
-  database: jail_dashboard_test
+  database: travis_ci_test


### PR DESCRIPTION
* Jasmine requires phantomJS 2.1.1 - we were running 1.9.8
* The test database connection should use
  the `DATABASE_HOST` environment variable instead of assuming localhost