### PR TITLE
Declare rubocop config file for Hound.

### DIFF
--- a/hound.yml
+++ b/hound.yml
@@ -4,3 +4,6 @@ jshint:
 eslint:
   enabled: true
   config_file: .eslintrc.json
+
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
Attempt to get Hound to stop alerting for single quoted strings.