### PR TITLE
Creates `sample_data:generate` task for generating people & weekly bookings

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -5,8 +5,8 @@ class Booking < ActiveRecord::Base
 
   validates :person_id, presence: true
 
-  PRE_TRIAL = 'pre-trial'
-  SENTENCED = 'sentenced'
+  PRE_TRIAL = 'pre-trial'.freeze
+  SENTENCED = 'sentenced'.freeze
 
   scope :active, -> { where(release_date_time: nil) }
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -5,8 +5,8 @@ class Booking < ActiveRecord::Base
 
   validates :person_id, presence: true
 
-  PRE_TRIAL = 'pre-trial'.freeze
-  SENTENCED = 'sentenced'.freeze
+  PRE_TRIAL = 'Pre-trial'.freeze
+  SENTENCED = 'Sentenced'.freeze
 
   scope :active, -> { where(release_date_time: nil) }
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,13 @@
 class Person < ActiveRecord::Base
   self.primary_key = :jms_person_id
     has_many :bookings, :foreign_key => :person_id, :primary_key => :jms_person_id
+
+  GENDERS = %w{male female}
+  RACES = [
+    'white',
+    'black',
+    'hispanic',
+    'asian or pacific islander',
+    'american indian or alaskan native'
+  ]
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,5 @@
 class Person < ActiveRecord::Base
+  GENDERS = %w{male female}.map!(&:freeze).freeze
   RACES = [
     'Alaska Native',
     'American Indian',
@@ -7,17 +8,8 @@ class Person < ActiveRecord::Base
     'Black or African American',
     'Hispanic',
     'Middle Eastern',
-  ].freeze
+  ].map!(&:freeze).freeze
 
   self.primary_key = :jms_person_id
   has_many :bookings, foreign_key: :person_id, primary_key: :jms_person_id
-
-  GENDERS = %w{male female}
-  RACES = [
-    'white',
-    'black',
-    'hispanic',
-    'asian or pacific islander',
-    'american indian or alaskan native'
-  ]
 end

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -40,7 +40,7 @@
       %h4 Processing Status
       %table.table.table-striped.table-responsive.processing-status
         -@active_bookings.group_by(&:status).each do |status, bookings|
-          %tr{class: status}
+          %tr{ class: status }
             %th=status.capitalize
             %td=bookings.count
             %td=present_percent(bookings.count, @active_bookings.count)

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -40,8 +40,8 @@
       %h4 Processing Status
       %table.table.table-striped.table-responsive.processing-status
         -@active_bookings.group_by(&:status).each do |status, bookings|
-          %tr{ class: status }
-            %th=status.capitalize
+          %tr{ class: status.downcase }
+            %th=status
             %td=bookings.count
             %td=present_percent(bookings.count, @active_bookings.count)
     .col-md-4

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -31,11 +31,10 @@
       %h4 Processing Status
       %table.table.table-striped.table-responsive.processing-status
         -@active_bookings.group_by(&:status).each do |status, bookings|
-          %tr{:class => status}
+          %tr{class: status}
             %th=status.capitalize
             %td=bookings.count
             %td=present_percent(bookings.count, @active_bookings.count)
-
     .col-md-4
       %h3 Charges Summary
       %br

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -41,9 +41,9 @@
       %table.table.table-striped.table-responsive.processing-status
         -@active_bookings.group_by(&:status).each do |status, bookings|
           %tr{ class: status.downcase }
-            %th=status
-            %td=bookings.count
-            %td=present_percent(bookings.count, @active_bookings.count)
+            %th= status
+            %td= bookings.count
+            %td= present_percent(bookings.count, @active_bookings.count)
     .col-md-4
       %h3 Charges Summary
       %br

--- a/lib/tasks/bookings.rake
+++ b/lib/tasks/bookings.rake
@@ -12,4 +12,31 @@ namespace :bookings do
       puts "bookings imported"
     end
   end
+
+  desc "generate bookings within the last week"
+  task :generate_weekly, [:count] => [:environment] do |t, args|
+    count = (args[:count] || 10).to_i
+
+    puts "Generating #{count} bookings within last week"
+    Booking.transaction do
+      people = Person.last(count)
+      facilities = ['Main Jail Complex', 'Medical Facility', 'County Correctional Center']
+
+      count.times do |index|
+        booking_date_time = Faker::Time.between(1.week.ago, DateTime.now)
+        booking = Booking.create!(
+          jms_booking_id: Faker::Code.ean,
+          booking_date_time: booking_date_time,
+          release_date_time: [booking_date_time, nil].sample,
+          inmate_number: Faker::Number.hexadecimal(10),
+          facility_name: facilities.sample,
+          cell_id: Faker::Address.building_number,
+          status: [Booking::PRE_TRIAL, Booking::SENTENCED].sample,
+          person_id: people[index].jms_person_id
+        )
+      end
+    end
+
+    puts "Successfully generated #{count} bookings within last week"
+  end
 end

--- a/lib/tasks/bookings.rake
+++ b/lib/tasks/bookings.rake
@@ -1,20 +1,20 @@
 namespace :bookings do
-  desc "import bookings data from flat file"
+  desc 'import bookings data from flat file'
   task import: :environment do
     require 'csv'
 
     Booking.transaction do
-      puts "reading bookings"
+      puts 'reading bookings'
       # This is a temporary path for the CSV; just wanted to get things up and running, will replace once ETL process more clearly defined
       bookings = CSV.read("#{Rails.root}/tmp/bookings.csv")
       columns = [:jms_booking_id, :person_id, :booking_date_time, :release_date_time, :inmate_number, :facility_name, :cell_id, :status]
       Booking.import columns, bookings, validate: false
-      puts "bookings imported"
+      puts 'bookings imported'
     end
   end
 
-  desc "generate bookings within the last week"
-  task :generate_weekly, [:count] => [:environment] do |t, args|
+  desc 'generate bookings within the last week'
+  task :generate_weekly, [:count] => [:environment] do |_, args|
     count = (args[:count] || 10).to_i
 
     puts "Generating #{count} bookings within last week"
@@ -24,7 +24,7 @@ namespace :bookings do
 
       count.times do |index|
         booking_date_time = Faker::Time.between(1.week.ago, DateTime.now)
-        booking = Booking.create!(
+        Booking.create!(
           jms_booking_id: Faker::Code.ean,
           booking_date_time: booking_date_time,
           release_date_time: [booking_date_time, nil].sample,

--- a/lib/tasks/bookings.rake
+++ b/lib/tasks/bookings.rake
@@ -23,7 +23,7 @@ namespace :bookings do
       facilities = ['Main Jail Complex', 'Medical Facility', 'County Correctional Center']
 
       count.times do |index|
-        booking_date_time = Faker::Time.between(1.week.ago, DateTime.now)
+        booking_date_time = Faker::Time.between(1.week.ago, DateTime.now.utc)
         Booking.create!(
           jms_booking_id: Faker::Code.ean,
           booking_date_time: booking_date_time,

--- a/lib/tasks/people.rake
+++ b/lib/tasks/people.rake
@@ -12,4 +12,25 @@ namespace :people do
       puts "people imported"
     end
   end
+
+  desc "generate people"
+  task :generate, [:count] => [:environment] do |t, args|
+    count = (args[:count] || 10).to_i
+
+    puts "Generating #{count} people..."
+    Person.transaction do
+      count.times do |index|
+        Person.create!(
+          jms_person_id: Faker::Code.isbn,
+          first_name: Faker::Name.first_name,
+          middle_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          date_of_birth: Faker::Time.between(70.years.ago, 18.years.ago),
+          gender: Person::GENDERS.sample,
+          race: Person::RACES.sample
+        )
+      end
+    end
+    puts "Successfully generated #{count} people"
+  end
 end

--- a/lib/tasks/people.rake
+++ b/lib/tasks/people.rake
@@ -1,25 +1,25 @@
 namespace :people do
-  desc "import people data from flat file"
+  desc 'import people data from flat file'
   task import: :environment do
     require 'csv'
 
     Person.transaction do
-      puts "reading people"
+      puts 'reading people'
       # This is a temporary path for the CSV; just wanted to get things up and running, will replace once ETL process more clearly defined
       people = CSV.read("#{Rails.root}/tmp/people.csv")
       columns = [:jms_person_id, :first_name, :middle_name, :last_name, :date_of_birth, :gender, :race]
       Person.import columns, people, validate: false
-      puts "people imported"
+      puts 'people imported'
     end
   end
 
-  desc "generate people"
-  task :generate, [:count] => [:environment] do |t, args|
+  desc 'generate people'
+  task :generate, [:count] => [:environment] do |_, args|
     count = (args[:count] || 10).to_i
 
     puts "Generating #{count} people..."
     Person.transaction do
-      count.times do |index|
+      count.times do
         Person.create!(
           jms_person_id: Faker::Code.isbn,
           first_name: Faker::Name.first_name,

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -1,0 +1,4 @@
+namespace :sample_data do
+  desc 'generate sample data'
+  task :generate, [:count] => ['people:generate', 'bookings:generate_weekly']
+end

--- a/spec/factories/bookings.rb
+++ b/spec/factories/bookings.rb
@@ -3,7 +3,7 @@ require 'faker'
 FactoryGirl.define do
   factory :booking do
     sequence(:jms_booking_id) { |n| format("%5d", n) }
-    person_id "11235"
+    association :person
     booking_date_time Faker::Time.backward(365)
     release_date_time nil
     inmate_number "24601"

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,13 +1,13 @@
 require 'faker'
 
 FactoryGirl.define do
-  factory :person do |f|
-    f.jms_person_id "11235"
-    f.first_name Faker::Name.first_name
-    f.middle_name Faker::Name.first_name
-    f.last_name Faker::Name.last_name
-    f.date_of_birth Faker::Time.between(DateTime.now - 1, DateTime.now)
-    f.gender "male"
-    f.race "white"
+  factory :person do
+    sequence(:jms_person_id) { |n| (11235 + n).to_s }
+    first_name { Faker::Name.first_name }
+    middle_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    date_of_birth { Faker::Time.between(DateTime.now - 1, DateTime.now) }
+    gender Person::GENDERS.first
+    race Person::RACES.first
   end
 end

--- a/spec/matchers/matchers_spec.rb
+++ b/spec/matchers/matchers_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'custom matchers' do
+  describe 'be_nil_or' do
+    describe nil do
+      it { is_expected.to be_nil_or(:<, 6) }
+    end
+
+    describe 5 do
+      it { is_expected.to be_nil_or(:<, 6) }
+    end
+
+    describe 7 do
+      it { is_expected.to_not be_nil_or(:<, 6) }
+    end
+
+    describe 1.week.ago do
+      it { is_expected.to be_nil_or(:<, DateTime.now) }
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :be_nil_or do |operator, number|
+  match do |actual|
+    actual.nil? || actual.send(operator, number)
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} would be nil or #{operator} #{number}"
+  end
+end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,12 +1,12 @@
-require "rake"
+require 'rake'
 
-shared_context "rake" do
+shared_context 'rake' do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
 
   def loaded_files_excluding_current_rake_file
-    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+    $".reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
   end
 
   def run_task(args = nil, verbose: false)

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,29 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  def run_task(args = nil, verbose: false)
+    if verbose
+      Rake::Task[task_name].invoke(args)
+    else
+      silence_stream(STDOUT) do
+        Rake::Task[task_name].invoke(args)
+      end
+    end
+  end
+
+  before(:each) do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+    Rake::Task[task_name].reenable
+  end
+end

--- a/spec/tasks/bookings_tasks_spec.rb
+++ b/spec/tasks/bookings_tasks_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'bookings rake tasks' do
+  describe 'bookings:generate_weekly' do
+    include_context 'rake'
+
+    before(:each) do
+      FactoryGirl.create_list(:person, 10)
+    end
+
+    let(:task_name) do
+      'bookings:generate_weekly'
+    end
+
+    it 'creates 10 bookings by default' do
+      expect {
+        run_task
+      }.to change{Booking.count}.by(10)
+    end
+
+    it 'accepts number of bookings to create as argument' do
+      expect {
+        run_task('3')
+      }.to change{Booking.count}.by(3)
+    end
+
+    it 'creates bookings within past week' do
+      run_task('3')
+
+      booking_dates = Booking.last(3).map(&:booking_date_time)
+
+      expect(booking_dates.first).to be_within(1.week).of(DateTime.now)
+      expect(booking_dates.second).to be_within(1.week).of(DateTime.now)
+      expect(booking_dates.third).to be_within(1.week).of(DateTime.now)
+    end
+
+    it 'assigns existing people to bookings' do
+      run_task('3')
+
+      existing_people_ids = Person.pluck(:jms_person_id)
+      actual_people_ids = Booking.last(3).map(&:person_id).uniq
+
+      expect(existing_people_ids).to include(*actual_people_ids)
+    end
+
+    it 'creates mix of current bookings, and with inactive bookings since booking date' do
+      run_task('3')
+
+      bookings = Booking.last(3)
+
+      expect(bookings.first.release_date_time).to be_nil_or(:>=, bookings.first.booking_date_time)
+      expect(bookings.second.release_date_time).to be_nil_or(:>=, bookings.second.booking_date_time)
+      expect(bookings.third.release_date_time).to be_nil_or(:>=, bookings.third.booking_date_time)
+    end
+
+    it 'assigns an existing facility name' do
+      run_task('3')
+
+      expected_facility_names = ["Main Jail Complex", "Medical Facility", "County Correctional Center"]
+      actual_facility_names = Booking.last(3).map(&:facility_name).uniq
+
+      expect(expected_facility_names).to include(*actual_facility_names)
+    end
+
+    it 'assigns a valid status' do
+      run_task('3')
+
+      expected_statuses = [Booking::PRE_TRIAL, Booking::SENTENCED]
+      actual_statuses = Booking.last(3).map(&:status).uniq
+
+      expect(expected_statuses).to include(*actual_statuses)
+    end
+  end
+end
+

--- a/spec/tasks/bookings_tasks_spec.rb
+++ b/spec/tasks/bookings_tasks_spec.rb
@@ -69,4 +69,3 @@ describe 'bookings rake tasks' do
     end
   end
 end
-

--- a/spec/tasks/bookings_tasks_spec.rb
+++ b/spec/tasks/bookings_tasks_spec.rb
@@ -14,15 +14,11 @@ describe 'bookings rake tasks' do
     end
 
     it 'creates 10 bookings by default' do
-      expect {
-        run_task
-      }.to change{Booking.count}.by(10)
+      expect { run_task }.to change { Booking.count }.by(10)
     end
 
     it 'accepts number of bookings to create as argument' do
-      expect {
-        run_task('3')
-      }.to change{Booking.count}.by(3)
+      expect { run_task('3') }.to change { Booking.count }.by(3)
     end
 
     it 'creates bookings within past week' do
@@ -57,7 +53,7 @@ describe 'bookings rake tasks' do
     it 'assigns an existing facility name' do
       run_task('3')
 
-      expected_facility_names = ["Main Jail Complex", "Medical Facility", "County Correctional Center"]
+      expected_facility_names = ['Main Jail Complex', 'Medical Facility', 'County Correctional Center']
       actual_facility_names = Booking.last(3).map(&:facility_name).uniq
 
       expect(expected_facility_names).to include(*actual_facility_names)

--- a/spec/tasks/bookings_tasks_spec.rb
+++ b/spec/tasks/bookings_tasks_spec.rb
@@ -26,9 +26,9 @@ describe 'bookings rake tasks' do
 
       booking_dates = Booking.last(3).map(&:booking_date_time)
 
-      expect(booking_dates.first).to be_within(1.week).of(DateTime.now)
-      expect(booking_dates.second).to be_within(1.week).of(DateTime.now)
-      expect(booking_dates.third).to be_within(1.week).of(DateTime.now)
+      expect(booking_dates.first).to be_within(1.week).of(DateTime.now.utc)
+      expect(booking_dates.second).to be_within(1.week).of(DateTime.now.utc)
+      expect(booking_dates.third).to be_within(1.week).of(DateTime.now.utc)
     end
 
     it 'assigns existing people to bookings' do

--- a/spec/tasks/people_tasks_spec.rb
+++ b/spec/tasks/people_tasks_spec.rb
@@ -10,15 +10,11 @@ describe 'people rake tasks' do
     end
 
     it 'creates 10 people by default' do
-      expect {
-        run_task
-      }.to change{Person.count}.by(10)
+      expect { run_task }.to change { Person.count }.by(10)
     end
 
     it 'accepts number of people to create as argument' do
-      expect {
-        run_task('3')
-      }.to change{Person.count}.by(3)
+      expect { run_task('3') }.to change { Person.count }.by(3)
     end
 
     it 'assigns age higher than 18 years' do

--- a/spec/tasks/people_tasks_spec.rb
+++ b/spec/tasks/people_tasks_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'people rake tasks' do
+  describe 'people:generate' do
+    include_context 'rake'
+
+    let(:task_name) do
+      'people:generate'
+    end
+
+    it 'creates 10 people by default' do
+      expect {
+        run_task
+      }.to change{Person.count}.by(10)
+    end
+
+    it 'accepts number of people to create as argument' do
+      expect {
+        run_task('3')
+      }.to change{Person.count}.by(3)
+    end
+
+    it 'assigns age higher than 18 years' do
+      run_task('3')
+
+      people_ages = Person.last(3).map(&:date_of_birth)
+
+      expect(people_ages.first).to be < 18.years.ago
+      expect(people_ages.second).to be < 18.years.ago
+      expect(people_ages.third).to be < 18.years.ago
+    end
+
+    it 'assigns existing gender' do
+      run_task('3')
+
+      actual_genders = Booking.last(3).map(&:gender)
+
+      expect(Person::GENDERS).to include(*actual_genders)
+    end
+
+    it 'assigns existing race' do
+      run_task('3')
+
+      actual_races = Booking.last(3).map(&:race)
+
+      expect(Person::RACES).to include(*actual_races)
+    end
+  end
+end
+


### PR DESCRIPTION
Uses existing fakedata task to create three new rake tasks for generating sample data for use in development. Does not write data to CSV — instead inserts directly in database.

* `rake sample_data:generate[count]`: Entrypoint for creating new data. Runs both `people:generate[count]` and `bookings:generate_weekly[count]` to generate a given number (default is 10) of people and bookings for the current week.
* `rake people:generate[count]`: Creates new sample people in database. Confines gender and race to existing values in application.
* `rake bookings:generate_weekly[count]`: Creates new sample bookings for last week in database. Varies whether they have been released or not. Restricts status and facility name to existing values in application.

Closes [#34](https://waffle.io/codeforamerica/jail-dashboard-project/cards/5848555feb07a191011fa941)