### PR TITLE
Only generate weekly bookings within last 6 days

### DIFF
--- a/lib/tasks/bookings.rake
+++ b/lib/tasks/bookings.rake
@@ -23,7 +23,7 @@ namespace :bookings do
       facilities = ['Main Jail Complex', 'Medical Facility', 'County Correctional Center']
 
       count.times do |index|
-        booking_date_time = Faker::Time.between(1.week.ago, DateTime.now.utc)
+        booking_date_time = Faker::Time.between(6.days.ago, DateTime.now)
         Booking.create!(
           jms_booking_id: Faker::Code.ean,
           booking_date_time: booking_date_time,

--- a/spec/tasks/bookings_tasks_spec.rb
+++ b/spec/tasks/bookings_tasks_spec.rb
@@ -26,9 +26,9 @@ describe 'bookings rake tasks' do
 
       booking_dates = Booking.last(3).map(&:booking_date_time)
 
-      expect(booking_dates.first).to be_within(1.week).of(DateTime.now.utc)
-      expect(booking_dates.second).to be_within(1.week).of(DateTime.now.utc)
-      expect(booking_dates.third).to be_within(1.week).of(DateTime.now.utc)
+      expect(booking_dates.first).to be_within(1.week).of(DateTime.now)
+      expect(booking_dates.second).to be_within(1.week).of(DateTime.now)
+      expect(booking_dates.third).to be_within(1.week).of(DateTime.now)
     end
 
     it 'assigns existing people to bookings' do


### PR DESCRIPTION
Tests were intermittently failing due to timezone issues. Since strict week time range doesn't matter for our sample data, we now only generate bookings within last 6 days as a fast fix.

Also reverts previous datetime conversion to utc, since this didn't help.