### PR TITLE
Healthcheck

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
 
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :healthcheck
 
   def home
     @people = Person.all
@@ -23,5 +23,8 @@ class PagesController < ApplicationController
         active_bookings: @bookings.active.count
       }
     )
+  end
+
+  def healthcheck
   end
 end

--- a/app/views/pages/healthcheck.html.haml
+++ b/app/views/pages/healthcheck.html.haml
@@ -1,0 +1,1 @@
+%p Success

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
 
   root 'pages#home'
-
+  get 'healthcheck' => 'pages#healthcheck'
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -28,4 +28,9 @@ describe 'sign in' do
     sign_in(user.email, 'abcde')
     expect(page).to have_content('Invalid Email or password.')
   end
+
+  it 'should allow a service to access the healthcheck without logging in' do
+    visit '/healthcheck'
+    expect(page).to have_content('Success')
+  end
 end


### PR DESCRIPTION
**Problem**

Skyliner's health checks were bumping on our before_action because they weren't set up to auth. 

**Solution**

Create an endpoint for the health check that doesn't undermine auth on other actions