### PR TITLE
Remove duplicate data from People section

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -6,14 +6,6 @@
       %h3 People Summary
       %br
 
-      %table.table.table-responsive
-        %tr
-          %th Total # people in system
-          %td= @people.count
-        %tr
-          %th People with active bookings
-          %td= @active_people.count
-
       %h4 Gender
       = render "grouping_table",
         records: @active_people,
@@ -29,7 +21,8 @@
     .col-md-4
       %h3 Bookings Summary
       %br
-      %table.table.table-responsive
+
+      %table.table.table-striped.table-responsive
         %tr
           %th Total # active bookings
           %td= @bookings.where(release_date_time: nil).count


### PR DESCRIPTION
From People Summary section, removes:
* Total # people in system
* People with active bookings

One was duplicate (already exists in bookings) and the other unused.

Before:
![screen shot 2016-12-13 at 3 55 18 pm](https://cloud.githubusercontent.com/assets/3675092/21164251/ccf5f25e-c14c-11e6-8de5-0ab9bf581dfc.png)

After:
![screen shot 2016-12-13 at 3 55 53 pm](https://cloud.githubusercontent.com/assets/3675092/21164256/d0315c42-c14c-11e6-91cc-cdf7fe1c0eaf.png)

Closes #65 