### PR TITLE
Make breakout charts respond to filters

### DIFF
--- a/app/assets/stylesheets/charts/population_capacity.scss
+++ b/app/assets/stylesheets/charts/population_capacity.scss
@@ -70,4 +70,12 @@ $warning-red: #dc0000;
   &:nth-child(7n + 5) th::before { background-color: $breakout-color-5; }
   &:nth-child(7n + 6) th::before { background-color: $breakout-color-6; }
   &:nth-child(7n + 7) th::before { background-color: $breakout-color-7; }
+
+  td {
+    width: 10%;
+  }
+
+  .breakdown-percentage {
+    text-align: right;
+  }
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -7,22 +7,6 @@
 
   .row
     .col-md-4
-      %h3 Demographics
-      %br
-
-      %h4 Gender
-      = render "grouping_table",
-        records: @active_people,
-        attribute: :gender,
-        html_class: 'demographics-gender'
-
-      %h4 Race
-      = render "grouping_table",
-        records: @active_people,
-        attribute: :race,
-        html_class: 'demographics-race'
-
-    .col-md-4
       %h3 Bookings Summary
       %br
 
@@ -30,13 +14,6 @@
         %tr
           %th Total # active bookings
           %td= @bookings.where(release_date_time: nil).count
-
-      %h4 Case Status
-
-      = render "grouping_table",
-        records: @active_bookings,
-        attribute: :status,
-        html_class: 'processing-status'
 
       %h4 Current Week
       %table.table.table-responsive.booking-stats
@@ -49,13 +26,6 @@
           %th #{released} (#{present_percent(released, bookings_one_week_ago)})
           %td people released
 
-      %h4 Location
-      = render "grouping_table",
-        records: @active_bookings,
-        attribute: :facility_name,
-        html_class: 'location'
-
-    .col-md-4
       %h3 Charges Summary
       %br
       %h4 By Category

--- a/spec/features/demographics_spec.rb
+++ b/spec/features/demographics_spec.rb
@@ -7,7 +7,7 @@ describe 'demographics' do
     login_as FactoryGirl.create(:user)
   end
 
-  it 'shows gender breakdown of actively booked people' do
+  it 'shows gender breakdown of actively booked people', :js do
     male = FactoryGirl.create(:person, gender: 'male')
     female = FactoryGirl.create(:person, gender: 'female')
     released = FactoryGirl.create(:person, gender: 'female')
@@ -18,13 +18,13 @@ describe 'demographics' do
 
     visit '/'
 
-    within('.demographics-gender') do
-      expect(page).to have_css('tr', text: 'Male 1 50.0%')
-      expect(page).to have_css('tr', text: 'Female 1 50.0%')
+    within('.filters') do
+      expect(page).to have_css('tr', text: 'male 1 50%')
+      expect(page).to have_css('tr', text: 'female 1 50%')
     end
   end
 
-  it 'shows race/ethnicity breakdown of actively booked people' do
+  it 'shows race/ethnicity breakdown of actively booked people', :js do
     Person::RACES.each do |race|
       active = FactoryGirl.create(:person, race: race)
       FactoryGirl.create(:booking, person: active)
@@ -37,12 +37,11 @@ describe 'demographics' do
 
     expected_percentage = number_to_percentage(
       100.0 / Person::RACES.count,
-      precision: 1,
+      precision: 0,
     )
-    within('.demographics-race') do
+    within('.filters') do
       Person::RACES.each do |race|
-        expect(page).
-          to have_css('tr', text: "#{race.titlecase} 1 #{expected_percentage}")
+        expect(page).to have_css('tr', text: "#{race} 1 #{expected_percentage}")
       end
     end
   end

--- a/spec/features/location_breakdown_spec.rb
+++ b/spec/features/location_breakdown_spec.rb
@@ -5,16 +5,16 @@ describe 'location' do
     login_as FactoryGirl.create(:user)
   end
 
-  it 'shows location breakdown of active bookings' do
+  it 'shows location breakdown of active bookings', :js do
     FactoryGirl.create(:booking, facility_name: 'Azkaban')
     FactoryGirl.create(:booking, facility_name: 'Alcatraz')
     FactoryGirl.create(:booking, :inactive, facility_name: 'Alcatraz')
 
     visit '/'
 
-    within('.location') do
-      expect(page).to have_css('tr', text: 'Alcatraz 1 50.0%')
-      expect(page).to have_css('tr', text: 'Azkaban 1 50.0%')
+    within('.filters') do
+      expect(page).to have_css('tr', text: 'Alcatraz 1 50%')
+      expect(page).to have_css('tr', text: 'Azkaban 1 50%')
     end
   end
 end

--- a/spec/features/processing_status_spec.rb
+++ b/spec/features/processing_status_spec.rb
@@ -5,7 +5,7 @@ describe 'processing status' do
     login_as FactoryGirl.create(:user)
   end
 
-  it 'shows active pre-trial & sentenced population counts and percentages' do
+  it 'shows active population status counts and percentages', :js do
     FactoryGirl.create(:booking, :inactive, status: Booking::PRE_TRIAL)
 
     FactoryGirl.create_list(:booking, 2, status: Booking::PRE_TRIAL)
@@ -13,9 +13,9 @@ describe 'processing status' do
 
     visit '/'
 
-    within('.processing-status') do
-      expect(page).to have_css('tr', text: 'Pre Trial 2 66.7%')
-      expect(page).to have_css('tr', text: 'Sentenced 1 33.3%')
+    within('.breakdown-table.status') do
+      expect(page).to have_css('.breakdown-row', text: 'Pre-trial 2 67%')
+      expect(page).to have_css('.breakdown-row', text: 'Sentenced 1 33%')
     end
   end
 end


### PR DESCRIPTION
Closes #85 

* Move the breakout chart rendering logic into d3
* Update the breakout charts whenever a filter is applied

TODO:

Breakout charts for a specific dimension
don't respond to filters for that dimension.