### PR TITLE
Make filtering links accessible

### DIFF
--- a/app/assets/javascripts/filter.js.es6
+++ b/app/assets/javascripts/filter.js.es6
@@ -61,6 +61,7 @@ class FilterTable {
 
       breakdownTable.append('tr')
         .attr('class', `breakdown-row ${className}`)
+        .attr('role', 'link')
         .on('click', () => {
           this.filters[dimensionName][segment.key] = !this.filters[dimensionName][segment.key];
           this.update();


### PR DESCRIPTION
We're using clickable `<tr>` elements to handle filtering,
but those elements have no indication that they are clickable.
Without a `role="link"` attribute,
people using screen readers or assistive devices
will not be able to act on the links.