### PR TITLE
Bring all dimensions/filters into filter.js

### DIFF
--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -38,8 +38,8 @@ window.runApplication = () => {
     d3.select('.historical')
   );
 
-  filter.onUpdate(historical.filtersUpdated.bind(historical));
+  // filter.onUpdate(historical.filtersUpdated.bind(historical));
 
   filter.render();
-  historical.render();
+  // historical.render();
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -34,4 +34,11 @@ window.runApplication = () => {
     d3.select('.filters'),
   );
   filter.render()
+
+  const historicalData = gon.crossfilter_historical
+  const historical = new HistoricalChart(
+    historicalData,
+    d3.select('.historical')
+  );
+  historical.render()
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -33,12 +33,13 @@ window.runApplication = () => {
     d3.select('.filtered-people'),
     d3.select('.filters'),
   );
-  filter.render()
 
-  const historicalData = gon.crossfilter_historical
   const historical = new HistoricalChart(
-    historicalData,
     d3.select('.historical')
   );
-  historical.render()
+
+  filter.onUpdate(historical.filtersUpdated.bind(historical));
+
+  filter.render();
+  historical.render();
 };

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -3,29 +3,21 @@ class HistoricalChart {
     this.data = data;
     this.chartElement = chartElement;
     this.dimensions = {};
+    this.filters = {};
+  }
+
+  filtersUpdated(data) {
+    this.data = data;
+
+    console.log(this.data);
+    debugger;
+    // this.update();
   }
 
   render() {
-    
-
-    // pre-formatting for dates
-    this.data.forEach(function(p) {   
-      p.booking_date_time = new Date(p.booking_date_time);
-
-      // keep nulls null; else a new Date on null will set in 1969
-      if (p.release_date_time == null) {
-        p.release_date_time = null
-      }
-      else {
-        p.release_date_time = new Date(p.release_date_time);
-      }
-    });
-
-    var bookings = crossfilter(this.data);
-
-    // define date-based filters
-    var byBooked = bookings.dimension(function(p) { return p.booking_date_time; });
-    var byReleased = bookings.dimension(function(p) { return p.release_date_time; });
+    console.log("in render: ");
+    console.log(this.data);
+    debugger;
 
     // dummy date for logging
     var currentDate = new Date(2016,3,18);

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -8,21 +8,14 @@ class HistoricalChart {
 
   filtersUpdated(data) {
     this.data = data;
-
+    console.log("filters updated: ");
     console.log(this.data);
-    debugger;
     // this.update();
   }
 
   render() {
     console.log("in render: ");
     console.log(this.data);
-    debugger;
-
-    // dummy date for logging
-    var currentDate = new Date(2016,3,18);
-    byBooked.filterFunction(d => d < currentDate);
-    byReleased.filterFunction(d => d == null || d > currentDate);
 
     // this should reflect total # of active bookings for currentDate
     console.log(bookings.groupAll().reduceCount().value());

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -1,0 +1,39 @@
+class HistoricalChart {
+  constructor(data, chartElement) {
+    this.data = data;
+    this.chartElement = chartElement;
+    this.dimensions = {};
+  }
+
+  render() {
+    
+
+    // pre-formatting for dates
+    this.data.forEach(function(p) {   
+      p.booking_date_time = new Date(p.booking_date_time);
+
+      // keep nulls null; else a new Date on null will set in 1969
+      if (p.release_date_time == null) {
+        p.release_date_time = null
+      }
+      else {
+        p.release_date_time = new Date(p.release_date_time);
+      }
+    });
+
+    var bookings = crossfilter(this.data);
+
+    // define date-based filters
+    var byBooked = bookings.dimension(function(p) { return p.booking_date_time; });
+    var byReleased = bookings.dimension(function(p) { return p.release_date_time; });
+
+    // dummy date for logging
+    var currentDate = new Date(2016,3,18);
+    byBooked.filterFunction(d => d < currentDate);
+    byReleased.filterFunction(d => d == null || d > currentDate);
+
+    // this should reflect total # of active bookings for currentDate
+    console.log(bookings.groupAll().reduceCount().value());
+
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,9 +25,8 @@ class PagesController < ApplicationController
         },
         active_bookings: @bookings.active.count
       },
-      crossfilter_data: crossfilter_data(@active_bookings),
+      crossfilter_data: crossfilter_data(@bookings),
       filters: filters,
-      crossfilter_historical: crossfilter_data(@bookings)
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,6 +27,7 @@ class PagesController < ApplicationController
       },
       crossfilter_data: crossfilter_data(@active_bookings),
       filters: filters,
+      crossfilter_historical: crossfilter_data(@bookings)
     )
   end
 
@@ -35,8 +36,8 @@ class PagesController < ApplicationController
 
   private
 
-  def crossfilter_data(active_bookings)
-    active_bookings.
+  def crossfilter_data(bookings)
+    bookings.
       joins(:person).
       select(
         :jms_person_id,

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -2,6 +2,7 @@
   .col-md-8
     .chart
     .filtered-people
+    .historical
   .col-md-4
     .filters
 


### PR DESCRIPTION
Consolidate filter/historical streams into a unified crossfilter branch
- all dimensions are set on `filter` 
- an updated filtered set of data is passed to `historical` on update/before render
- on render, the current date is used to filter current active records

TODO (next steps):
- take data from `filtersUpdated` and generate counts for line chart (@jennifermarie)
- extract filter controls & pass selected bookings to tables/visuals via  `tableCallback(selectedBookingsAtSinglePointInTime)` (@graysonwright)