### PR TITLE
Historical trendline chart

### DIFF
--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -38,8 +38,8 @@ window.runApplication = () => {
     d3.select('.historical')
   );
 
-  filter.onUpdate(historical.filtersUpdated.bind(historical));
+  // filter.onUpdate(historical.filtersUpdated.bind(historical));
 
   filter.render();
-  historical.render();
+  // historical.render();
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -38,6 +38,6 @@ window.runApplication = () => {
     d3.select('.historical')
   );
 
-  filter.onUpdate(historical.filtersUpdated.bind(historical));
+  filter.onUpdate(data => historical.filtersUpdated(data));
   filter.render();
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -38,8 +38,6 @@ window.runApplication = () => {
     d3.select('.historical')
   );
 
-  // filter.onUpdate(historical.filtersUpdated.bind(historical));
-
+  filter.onUpdate(historical.filtersUpdated.bind(historical));
   filter.render();
-  // historical.render();
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -34,4 +34,11 @@ window.runApplication = () => {
     d3.select('.filters'),
   );
   filter.render()
+
+  const historicalData = gon.crossfilter_historical
+  const historical = new HistoricalChart(
+    historicalData,
+    d3.select('.historical')
+  );
+  historical.render()
 };

--- a/app/assets/javascripts/application.js.es6
+++ b/app/assets/javascripts/application.js.es6
@@ -33,12 +33,13 @@ window.runApplication = () => {
     d3.select('.filtered-people'),
     d3.select('.filters'),
   );
-  filter.render()
 
-  const historicalData = gon.crossfilter_historical
   const historical = new HistoricalChart(
-    historicalData,
     d3.select('.historical')
   );
-  historical.render()
+
+  filter.onUpdate(historical.filtersUpdated.bind(historical));
+
+  filter.render();
+  historical.render();
 };

--- a/app/assets/javascripts/filter.js.es6
+++ b/app/assets/javascripts/filter.js.es6
@@ -120,6 +120,10 @@ class FilterTable {
         this.dimensions[dimensionName].filterFunction(d => this.filters[dimensionName][d]);
     });
 
+    // clear time-bound filters
+    this.dimensions.bookingDateTime.filterAll();
+    this.dimensions.releaseDateTime.filterAll();
+
     // call update callbacks with historical data
     let selectedBookings = this.dimensions.lengthOfStay.top(Infinity);
     this.onUpdateCallbacks.forEach(callback => callback(selectedBookings));

--- a/app/assets/javascripts/filter.js.es6
+++ b/app/assets/javascripts/filter.js.es6
@@ -17,7 +17,7 @@ class FilterTable {
 
       // keep nulls null; else a new Date on null will set in 1969
       if (p.release_date_time == null) {
-        p.release_date_time = null
+        p.release_date_time = null;
       }
       else {
         p.release_date_time = new Date(p.release_date_time);
@@ -108,7 +108,7 @@ class FilterTable {
   }
 
   onUpdate(callback) {
-     this.onUpdateCallbacks = this.onUpdateCallbacks.concat(callback);
+    this.onUpdateCallbacks = this.onUpdateCallbacks.concat(callback);
   }
 
   update() {

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -21,7 +21,7 @@ class HistoricalChart {
       var dates = [counterDate];
 
       while (latestDate >= counterDate) {
-        week = counterDate.getDate() + 7  
+        week = counterDate.getDate() + 7;  
         counterDate = new Date(counterDate.setDate(++week));
         dates.push(counterDate);
       }
@@ -41,12 +41,12 @@ class HistoricalChart {
         bookingDateTime.filterFunction(d => d < currentDate);
         releaseDateTime.filterFunction(d => d == null || d > currentDate);
         counts.push(bookings.groupAll().reduceCount().value());
-        bookingDateTime.dispose()
-        releaseDateTime.dispose()
+        bookingDateTime.dispose();
+        releaseDateTime.dispose();
       });
       return counts;
     }
-    this.counts = getCounts()
+    this.counts = getCounts();
 
     var data = [{
       date: datesArray,

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -2,8 +2,6 @@ class HistoricalChart {
   constructor(data, chartElement) {
     this.data = data;
     this.chartElement = chartElement;
-    this.dimensions = {};
-    this.filters = {};
     this.counts = [];
   }
 
@@ -13,134 +11,137 @@ class HistoricalChart {
   }
 
   render() {
+    var datesArray = this.setDates();
 
-    function setDates() {
-      var latestDate = new Date();
-      var counterDate = new Date(2016, 1, 1);
-      var week;
-      var dates = [counterDate];
-
-      while (latestDate >= counterDate) {
-        week = counterDate.getDate() + 7;  
-        counterDate = new Date(counterDate.setDate(++week));
-        dates.push(counterDate);
-      }
-      return dates;
-    }
-
-    var datesArray = setDates();
-
-    var bookings = crossfilter(this.data);
-
-    function getCounts() {
-      var counts = [];
-      datesArray.forEach(function (date) {
-        let currentDate = date;
-        var bookingDateTime = bookings.dimension(d => d.booking_date_time);
-        var releaseDateTime = bookings.dimension(d => d.release_date_time);
-        bookingDateTime.filterFunction(d => d < currentDate);
-        releaseDateTime.filterFunction(d => d == null || d > currentDate);
-        counts.push(bookings.groupAll().reduceCount().value());
-        bookingDateTime.dispose();
-        releaseDateTime.dispose();
-      });
-      return counts;
-    }
-    this.counts = getCounts();
+    this.counts = this.getCounts(datesArray);
 
     var data = [{
       date: datesArray,
       count: this.counts
     }];
 
-    var xy_chart = d3_xy_chart()
+    var xy_chart = this.d3_xy_chart()
 
     var svg = d3.select('.historical').append('svg')
       .datum(data)
       .call(xy_chart);
 
-    function d3_xy_chart() {
-      var width = document.getElementsByClassName('historical')[0].getBoundingClientRect().width,
-        height = 480;
 
-      function chart(selection) {
-        selection.each(function (datasets) {
-          var margin = {
-              top: 20,
-              right: 30,
-              bottom: 30,
-              left: 30
-            },
-            innerwidth = width - margin.left - margin.right,
-            innerheight = height - margin.top - margin.bottom;
-          var x_scale = d3.scaleTime()
-            .range([0, innerwidth])
-            .domain([d3.min(datasets, d => d3.min(d.date)),
-              d3.max(datasets, d => d3.max(d.date))
-            ]);
-          var y_scale = d3.scaleLinear()
-            .range([innerheight, 0])
-            .domain([0, d3.max(datasets, d => d3.max(d.count))]);
-          var x_axis = d3.axisBottom(x_scale);
-          var y_axis = d3.axisLeft(y_scale);
-          var draw_line = d3.line()
-            .x(d => x_scale(d[0]))
-            .y(d => y_scale(d[1]));
-          var svg = d3.select(this)
-            .attr('width', width)
-            .attr('height', height)
-            .append('g')
-            .attr('transform', `translate(${margin.left},${margin.top})`);
-
-          svg.append('g')
-            .attr('class', 'x axis')
-            .attr('transform', 'translate(0,' + innerheight + ')')
-            .call(x_axis)
-            .append('text')
-            .attr('dy', '-.71em')
-            .attr('x', innerwidth)
-            .style('text-anchor', 'end');
-
-          svg.append('g')
-            .attr('class', 'y axis')
-            .call(y_axis)
-            .append('text')
-            .attr('transform', 'rotate(-90)')
-            .attr('y', 6)
-            .attr('dy', '0.71em')
-            .style('text-anchor', 'end');
-
-          var data_lines = svg.selectAll('.d3_xy_chart_line')
-            .data(datasets.map(d => d3.zip(d.date, d.count)))
-            .enter().append('g')
-            .attr('class', 'd3_xy_chart_line');
-
-          data_lines.append('path')
-            .attr('class', 'line')
-            .attr('d', d => draw_line(d))
-            .attr('fill', 'white')
-            .attr('stroke', 'lightseagreen');
-        });
-      }
-
-      chart.width = function (value) {
-        if (!arguments.length) return width;
-        width = value;
-        return chart;
-      };
-
-      chart.height = function (value) {
-        if (!arguments.length) return height;
-        height = value;
-        return chart;
-      };
-
-      return chart;
-    }
   }
+
+  d3_xy_chart() {
+    var width = document.getElementsByClassName('historical')[0].getBoundingClientRect().width,
+      height = 480;
+
+    function chart(selection) {
+      selection.each(function (datasets) {
+        var margin = {
+            top: 20,
+            right: 30,
+            bottom: 30,
+            left: 30
+          },
+          innerwidth = width - margin.left - margin.right,
+          innerheight = height - margin.top - margin.bottom;
+        var x_scale = d3.scaleTime()
+          .range([0, innerwidth])
+          .domain([d3.min(datasets, d => d3.min(d.date)),
+            d3.max(datasets, d => d3.max(d.date))
+          ]);
+        var y_scale = d3.scaleLinear()
+          .range([innerheight, 0])
+          .domain([0, d3.max(datasets, d => d3.max(d.count))]);
+        var x_axis = d3.axisBottom(x_scale);
+        var y_axis = d3.axisLeft(y_scale);
+        var draw_line = d3.line()
+          .x(d => x_scale(d[0]))
+          .y(d => y_scale(d[1]));
+        var svg = d3.select(this)
+          .attr('width', width)
+          .attr('height', height)
+          .append('g')
+          .attr('transform', `translate(${margin.left},${margin.top})`);
+
+        svg.append('g')
+          .attr('class', 'x axis')
+          .attr('transform', 'translate(0,' + innerheight + ')')
+          .call(x_axis)
+          .append('text')
+          .attr('dy', '-.71em')
+          .attr('x', innerwidth)
+          .style('text-anchor', 'end');
+
+        svg.append('g')
+          .attr('class', 'y axis')
+          .call(y_axis)
+          .append('text')
+          .attr('transform', 'rotate(-90)')
+          .attr('y', 6)
+          .attr('dy', '0.71em')
+          .style('text-anchor', 'end');
+
+        var data_lines = svg.selectAll('.d3_xy_chart_line')
+          .data(datasets.map(d => d3.zip(d.date, d.count)))
+          .enter().append('g')
+          .attr('class', 'd3_xy_chart_line');
+
+        data_lines.append('path')
+          .attr('class', 'line')
+          .attr('d', d => draw_line(d))
+          .attr('fill', 'white')
+          .attr('stroke', 'lightseagreen');
+      });
+    }
+
+    chart.width = function (value) {
+      if (!arguments.length) return width;
+      width = value;
+      return chart;
+    };
+
+    chart.height = function (value) {
+      if (!arguments.length) return height;
+      height = value;
+      return chart;
+    };
+
+    return chart;
+  }
+
+  
 
   update() {
     this.redraw(this.chartElement);
+  }
+
+  setDates() {
+    var latestDate = new Date();
+    var counterDate = new Date(2016, 1, 1);
+    var week;
+    var dates = [counterDate];
+
+    while (latestDate >= counterDate) {
+      week = counterDate.getDate() + 7;  
+      counterDate = new Date(counterDate.setDate(++week));
+      dates.push(counterDate);
+    }
+    return dates;
+  }
+
+  getCounts(dates) {
+    var bookings = crossfilter(this.data);
+    var counts = [];
+    dates.forEach(function (date) {
+      let currentDate = date;
+      var bookingDateTime = bookings.dimension(d => d.booking_date_time);
+      var releaseDateTime = bookings.dimension(d => d.release_date_time);
+      bookingDateTime.filterFunction(d => d < currentDate);
+      releaseDateTime.filterFunction(d => d == null || d > currentDate);
+      counts.push(bookings.groupAll().reduceCount().value());
+      bookingDateTime.dispose();
+      releaseDateTime.dispose();
+    });
+    return counts;
   }
 
   redraw() {

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -21,7 +21,7 @@ class HistoricalChart {
       var dates = [counterDate];
 
       while (latestDate >= counterDate) {
-        week = counterDate.getDate() + 7
+        week = counterDate.getDate() + 7  
         counterDate = new Date(counterDate.setDate(++week));
         dates.push(counterDate);
       }
@@ -65,7 +65,6 @@ class HistoricalChart {
 
       function chart(selection) {
         selection.each(function (datasets) {
-
           var margin = {
               top: 20,
               right: 30,
@@ -74,45 +73,24 @@ class HistoricalChart {
             },
             innerwidth = width - margin.left - margin.right,
             innerheight = height - margin.top - margin.bottom;
-
           var x_scale = d3.scaleTime()
             .range([0, innerwidth])
-            .domain([d3.min(datasets, function (d) {
-                return d3.min(d.date);
-              }),
-              d3.max(datasets, function (d) {
-                return d3.max(d.date);
-              })
+            .domain([d3.min(datasets, d => d3.min(d.date)),
+              d3.max(datasets, d => d3.max(d.date))
             ]);
-
           var y_scale = d3.scaleLinear()
             .range([innerheight, 0])
-            .domain([d3.min(datasets, function (d) {
-                return d3.min(d.count);
-              }),
-              d3.max(datasets, function (d) {
-                return d3.max(d.count);
-              })
-            ]);
-
-
-
+            .domain([0, d3.max(datasets, d => d3.max(d.count))]);
           var x_axis = d3.axisBottom(x_scale);
-
           var y_axis = d3.axisLeft(y_scale);
-
-
-
           var draw_line = d3.line()
             .x(d => x_scale(d[0]))
             .y(d => y_scale(d[1]));
-
           var svg = d3.select(this)
             .attr('width', width)
             .attr('height', height)
             .append('g')
             .attr('transform', `translate(${margin.left},${margin.top})`);
-
 
           svg.append('g')
             .attr('class', 'x axis')
@@ -142,7 +120,6 @@ class HistoricalChart {
             .attr('d', d => draw_line(d))
             .attr('fill', 'white')
             .attr('stroke', 'lightseagreen');
-
         });
       }
 

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -55,12 +55,12 @@ class HistoricalChart {
 
     var xy_chart = d3_xy_chart()
 
-    var svg = d3.select(".historical").append("svg")
+    var svg = d3.select('.historical').append('svg')
       .datum(data)
       .call(xy_chart);
 
     function d3_xy_chart() {
-      var width = document.getElementsByClassName("historical")[0].getBoundingClientRect().width,
+      var width = document.getElementsByClassName('historical')[0].getBoundingClientRect().width,
         height = 480;
 
       function chart(selection) {
@@ -108,40 +108,40 @@ class HistoricalChart {
             .y(d => y_scale(d[1]));
 
           var svg = d3.select(this)
-            .attr("width", width)
-            .attr("height", height)
-            .append("g")
-            .attr("transform", `translate(${margin.left},${margin.top})`);
+            .attr('width', width)
+            .attr('height', height)
+            .append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`);
 
 
-          svg.append("g")
-            .attr("class", "x axis")
-            .attr("transform", "translate(0," + innerheight + ")")
+          svg.append('g')
+            .attr('class', 'x axis')
+            .attr('transform', 'translate(0,' + innerheight + ')')
             .call(x_axis)
-            .append("text")
-            .attr("dy", "-.71em")
-            .attr("x", innerwidth)
-            .style("text-anchor", "end");
+            .append('text')
+            .attr('dy', '-.71em')
+            .attr('x', innerwidth)
+            .style('text-anchor', 'end');
 
-          svg.append("g")
-            .attr("class", "y axis")
+          svg.append('g')
+            .attr('class', 'y axis')
             .call(y_axis)
-            .append("text")
-            .attr("transform", "rotate(-90)")
-            .attr("y", 6)
-            .attr("dy", "0.71em")
-            .style("text-anchor", "end");
+            .append('text')
+            .attr('transform', 'rotate(-90)')
+            .attr('y', 6)
+            .attr('dy', '0.71em')
+            .style('text-anchor', 'end');
 
-          var data_lines = svg.selectAll(".d3_xy_chart_line")
+          var data_lines = svg.selectAll('.d3_xy_chart_line')
             .data(datasets.map(d => d3.zip(d.date, d.count)))
-            .enter().append("g")
-            .attr("class", "d3_xy_chart_line");
+            .enter().append('g')
+            .attr('class', 'd3_xy_chart_line');
 
-          data_lines.append("path")
-            .attr("class", "line")
-            .attr("d", d => draw_line(d))
-            .attr("fill", "white")
-            .attr("stroke", "lightseagreen");
+          data_lines.append('path')
+            .attr('class', 'line')
+            .attr('d', d => draw_line(d))
+            .attr('fill', 'white')
+            .attr('stroke', 'lightseagreen');
 
         });
       }
@@ -167,7 +167,7 @@ class HistoricalChart {
   }
 
   redraw() {
-    var svg = document.getElementsByClassName("historical")[0];
+    var svg = document.getElementsByClassName('historical')[0];
     while (svg.firstChild) {
       svg.removeChild(svg.firstChild);
     }

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -3,29 +3,21 @@ class HistoricalChart {
     this.data = data;
     this.chartElement = chartElement;
     this.dimensions = {};
+    this.filters = {};
+  }
+
+  filtersUpdated(data) {
+    this.data = data;
+
+    console.log(this.data);
+    debugger;
+    // this.update();
   }
 
   render() {
-    
-
-    // pre-formatting for dates
-    this.data.forEach(function(p) {   
-      p.booking_date_time = new Date(p.booking_date_time);
-
-      // keep nulls null; else a new Date on null will set in 1969
-      if (p.release_date_time == null) {
-        p.release_date_time = null
-      }
-      else {
-        p.release_date_time = new Date(p.release_date_time);
-      }
-    });
-
-    var bookings = crossfilter(this.data);
-
-    // define date-based filters
-    var byBooked = bookings.dimension(function(p) { return p.booking_date_time; });
-    var byReleased = bookings.dimension(function(p) { return p.release_date_time; });
+    console.log("in render: ");
+    console.log(this.data);
+    debugger;
 
     // dummy date for logging
     var currentDate = new Date(2016,3,18);

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -4,21 +4,173 @@ class HistoricalChart {
     this.chartElement = chartElement;
     this.dimensions = {};
     this.filters = {};
+    this.counts = [];
   }
 
   filtersUpdated(data) {
     this.data = data;
-    console.log("filters updated: ");
-    console.log(this.data);
-    // this.update();
+    this.update();
   }
 
   render() {
-    console.log("in render: ");
-    console.log(this.data);
 
-    // this should reflect total # of active bookings for currentDate
-    console.log(bookings.groupAll().reduceCount().value());
+    function setDates() {
+      var latestDate = new Date();
+      var counterDate = new Date(2016, 1, 1);
+      var week;
+      var dates = [counterDate];
 
+      while (latestDate >= counterDate) {
+        week = counterDate.getDate() + 7
+        counterDate = new Date(counterDate.setDate(++week));
+        dates.push(counterDate);
+      }
+      return dates;
+    }
+
+    var datesArray = setDates();
+
+    var bookings = crossfilter(this.data);
+
+    function getCounts() {
+      var counts = [];
+      datesArray.forEach(function (date) {
+        let currentDate = date;
+        var bookingDateTime = bookings.dimension(d => d.booking_date_time);
+        var releaseDateTime = bookings.dimension(d => d.release_date_time);
+        bookingDateTime.filterFunction(d => d < currentDate);
+        releaseDateTime.filterFunction(d => d == null || d > currentDate);
+        counts.push(bookings.groupAll().reduceCount().value());
+        bookingDateTime.dispose()
+        releaseDateTime.dispose()
+      });
+      return counts;
+    }
+    this.counts = getCounts()
+
+    var data = [{
+      date: datesArray,
+      count: this.counts
+    }];
+
+    var xy_chart = d3_xy_chart()
+
+    var svg = d3.select(".historical").append("svg")
+      .datum(data)
+      .call(xy_chart);
+
+    function d3_xy_chart() {
+      var width = document.getElementsByClassName("historical")[0].getBoundingClientRect().width,
+        height = 480;
+
+      function chart(selection) {
+        selection.each(function (datasets) {
+
+          var margin = {
+              top: 20,
+              right: 30,
+              bottom: 30,
+              left: 30
+            },
+            innerwidth = width - margin.left - margin.right,
+            innerheight = height - margin.top - margin.bottom;
+
+          var x_scale = d3.scaleTime()
+            .range([0, innerwidth])
+            .domain([d3.min(datasets, function (d) {
+                return d3.min(d.date);
+              }),
+              d3.max(datasets, function (d) {
+                return d3.max(d.date);
+              })
+            ]);
+
+          var y_scale = d3.scaleLinear()
+            .range([innerheight, 0])
+            .domain([d3.min(datasets, function (d) {
+                return d3.min(d.count);
+              }),
+              d3.max(datasets, function (d) {
+                return d3.max(d.count);
+              })
+            ]);
+
+
+
+          var x_axis = d3.axisBottom(x_scale);
+
+          var y_axis = d3.axisLeft(y_scale);
+
+
+
+          var draw_line = d3.line()
+            .x(d => x_scale(d[0]))
+            .y(d => y_scale(d[1]));
+
+          var svg = d3.select(this)
+            .attr("width", width)
+            .attr("height", height)
+            .append("g")
+            .attr("transform", `translate(${margin.left},${margin.top})`);
+
+
+          svg.append("g")
+            .attr("class", "x axis")
+            .attr("transform", "translate(0," + innerheight + ")")
+            .call(x_axis)
+            .append("text")
+            .attr("dy", "-.71em")
+            .attr("x", innerwidth)
+            .style("text-anchor", "end");
+
+          svg.append("g")
+            .attr("class", "y axis")
+            .call(y_axis)
+            .append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", 6)
+            .attr("dy", "0.71em")
+            .style("text-anchor", "end");
+
+          var data_lines = svg.selectAll(".d3_xy_chart_line")
+            .data(datasets.map(d => d3.zip(d.date, d.count)))
+            .enter().append("g")
+            .attr("class", "d3_xy_chart_line");
+
+          data_lines.append("path")
+            .attr("class", "line")
+            .attr("d", d => draw_line(d))
+            .attr("fill", "white")
+            .attr("stroke", "lightseagreen");
+
+        });
+      }
+
+      chart.width = function (value) {
+        if (!arguments.length) return width;
+        width = value;
+        return chart;
+      };
+
+      chart.height = function (value) {
+        if (!arguments.length) return height;
+        height = value;
+        return chart;
+      };
+
+      return chart;
+    }
+  }
+
+  update() {
+    this.redraw(this.chartElement);
+  }
+
+  redraw() {
+    var svg = document.getElementsByClassName("historical")[0];
+    while (svg.firstChild) {
+      svg.removeChild(svg.firstChild);
+    }
+    this.render();
   }
 }

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -8,21 +8,14 @@ class HistoricalChart {
 
   filtersUpdated(data) {
     this.data = data;
-
+    console.log("filters updated: ");
     console.log(this.data);
-    debugger;
     // this.update();
   }
 
   render() {
     console.log("in render: ");
     console.log(this.data);
-    debugger;
-
-    // dummy date for logging
-    var currentDate = new Date(2016,3,18);
-    byBooked.filterFunction(d => d < currentDate);
-    byReleased.filterFunction(d => d == null || d > currentDate);
 
     // this should reflect total # of active bookings for currentDate
     console.log(bookings.groupAll().reduceCount().value());

--- a/app/assets/javascripts/historical.js.es6
+++ b/app/assets/javascripts/historical.js.es6
@@ -1,0 +1,39 @@
+class HistoricalChart {
+  constructor(data, chartElement) {
+    this.data = data;
+    this.chartElement = chartElement;
+    this.dimensions = {};
+  }
+
+  render() {
+    
+
+    // pre-formatting for dates
+    this.data.forEach(function(p) {   
+      p.booking_date_time = new Date(p.booking_date_time);
+
+      // keep nulls null; else a new Date on null will set in 1969
+      if (p.release_date_time == null) {
+        p.release_date_time = null
+      }
+      else {
+        p.release_date_time = new Date(p.release_date_time);
+      }
+    });
+
+    var bookings = crossfilter(this.data);
+
+    // define date-based filters
+    var byBooked = bookings.dimension(function(p) { return p.booking_date_time; });
+    var byReleased = bookings.dimension(function(p) { return p.release_date_time; });
+
+    // dummy date for logging
+    var currentDate = new Date(2016,3,18);
+    byBooked.filterFunction(d => d < currentDate);
+    byReleased.filterFunction(d => d == null || d > currentDate);
+
+    // this should reflect total # of active bookings for currentDate
+    console.log(bookings.groupAll().reduceCount().value());
+
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,9 +25,8 @@ class PagesController < ApplicationController
         },
         active_bookings: @bookings.active.count
       },
-      crossfilter_data: crossfilter_data(@active_bookings),
+      crossfilter_data: crossfilter_data(@bookings),
       filters: filters,
-      crossfilter_historical: crossfilter_data(@bookings)
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,6 +27,7 @@ class PagesController < ApplicationController
       },
       crossfilter_data: crossfilter_data(@active_bookings),
       filters: filters,
+      crossfilter_historical: crossfilter_data(@bookings)
     )
   end
 
@@ -35,8 +36,8 @@ class PagesController < ApplicationController
 
   private
 
-  def crossfilter_data(active_bookings)
-    active_bookings.
+  def crossfilter_data(bookings)
+    bookings.
       joins(:person).
       select(
         :jms_person_id,

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -2,6 +2,7 @@
   .col-md-8
     .chart
     .filtered-people
+    .historical
   .col-md-4
     .filters
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -1,8 +1,8 @@
 .row
   .col-md-8
     .chart
-    .filtered-people
     .historical
+    .filtered-people
   .col-md-4
     .filters
 


### PR DESCRIPTION

![filters](https://cloud.githubusercontent.com/assets/1070220/21438299/13d3d96a-c83d-11e6-8389-cd6295268b0a.gif)

Couple of quick notes:
- There’s a big refactor opportunity but I held off because I wasn’t sure about the best place to put the date/count stuff since there's a ticket (#97) for extracting out the filters — it’s in `historical.js` right now but I basically duped the active pop count filter from `filter.js` inside of the `getCounts()` function, so that feels like it could be nicer
- Right now, I’m grabbing date points for the trendline in weekly batches — daily was super expensive
