### PR TITLE
prevent overly-long tables 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,4 +18,5 @@
 .tidy {
   height: 400px;
   overflow-y: scroll;
+  margin-bottom: 3em;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,6 @@
 @import "charts/population_capacity";
 
 .tidy {
-  height: 600px;
-  overflow: scroll;
+  height: 400px;
+  overflow-y: scroll;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,6 @@
 
 .tidy {
   height: 400px;
-  overflow-y: scroll;
   margin-bottom: 3em;
+  overflow-y: scroll;
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -2,22 +2,22 @@
   .col-md-8
     .chart
     .historical
-    .filtered-people
+    .filtered-people.tidy
 
     .bonds
       %h3 People who didn't post bond
       %p Current inmates with $500 or smaller bonds
-
-      %table.table.table-striped.table-responsive
-        %thead
-          %tr
-            %th Name
-            %th Bond
-        %tbody
-          - @target_bond_people.each do |person|
+      .tidy
+        %table.table.table-striped.table-responsive
+          %thead
             %tr
-              %th #{person.last_name}, #{person.first_name}
-              %td= number_to_currency(person.active_booking.bond_total, precision: 0)
+              %th Name
+              %th Bond
+          %tbody
+            - @target_bond_people.each do |person|
+              %tr
+                %th #{person.last_name}, #{person.first_name}
+                %td= number_to_currency(person.active_booking.bond_total, precision: 0)
 
   .col-md-4
     .filters


### PR DESCRIPTION
Closes #112 

### Problem
The tables for the lists of (filterable) people / people who didn't post bond were excessively long in unfiltered state.

### Solution
Set a height of 400 for each section, with scroll on overflow-y. The visible scrollbar should make it clear to the user that there are more people in the table, but the page will not be so long as to obscure additional sections.